### PR TITLE
Feature/querySelector

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -25,15 +25,15 @@ Document.prototype.createTextNode = function (text) {
 }
 
 Document.prototype.getElementsByTagName = function (tagName) {
-  const lowerTagName = tagName.toLowerCase();
+  const lowerTagName = tagName.toLowerCase()
 
   if (lowerTagName === 'html') {
-    return [this.documentElement];
+    return [this.documentElement]
   }
 
   return (lowerTagName === '*'
     ? [this.documentElement].concat(this.documentElement.getElementsByTagName(lowerTagName))
-    : this.documentElement.getElementsByTagName(lowerTagName));
+    : this.documentElement.getElementsByTagName(lowerTagName))
 }
 
 Document.prototype.getElementsByClassName = function (classNames) {
@@ -60,26 +60,26 @@ Document.prototype.getElementsByClassName = function (classNames) {
 
 Document.prototype.getElementById = function (id) {
   if (this.documentElement.id === id) {
-    return this.documentElement;
+    return this.documentElement
   }
 
   function matchIdInNodes(id, nodes) {
-    let nextContext = [];
+    let nextContext = []
 
     for (let i = 0; i < nodes.length; i++) {
       if (nodes[i].id === id) {
-        return nodes[i];
+        return nodes[i]
       }
 
-      nextContext = nextContext.concat(nodes[i].childNodes);
+      nextContext = nextContext.concat(nodes[i].childNodes)
     }
 
     if (nextContext.length > 0) {
-      return matchIdInNodes(id, nextContext);
+      return matchIdInNodes(id, nextContext)
     }
 
-    return null;
+    return null
   }
 
-  return matchIdInNodes(id, this.documentElement.childNodes);
+  return matchIdInNodes(id, this.documentElement.childNodes)
 }

--- a/lib/document.js
+++ b/lib/document.js
@@ -1,5 +1,6 @@
 import { HTMLElement } from './htmlelement'
 import { TextNode } from './textnode'
+import { querySelector } from './utils/querySelector'
 
 export function Document () {
   this.documentElement = this.createElement('html')
@@ -82,4 +83,8 @@ Document.prototype.getElementById = function (id) {
   }
 
   return matchIdInNodes(id, this.documentElement.childNodes)
+}
+
+Document.prototype.querySelector = function (query) {
+  return querySelector(query, this)
 }

--- a/lib/htmlelement.js
+++ b/lib/htmlelement.js
@@ -1,6 +1,7 @@
 import { ClassList } from './classlist'
 import { Node } from './node'
 import { TextNode } from './textnode'
+import { querySelector } from './utils/querySelector';
 
 const voidElementLookup = 'area base br col command embed hr img input keygen link meta param source track wbr'.split(' ').reduce(function (lookup, tagName) {
   lookup[tagName] = true
@@ -202,6 +203,10 @@ HTMLElement.prototype.getElementsByClassName = function (classNames) {
       ? results.concat(child, child.getElementsByClassName(classNames))
       : results.concat(child.getElementsByClassName(classNames)))
   }, [])
+}
+
+HTMLElement.prototype.querySelector = function (query) {
+  return querySelector(query, this)
 }
 
 Object.defineProperties(HTMLElement.prototype, {

--- a/lib/htmlelement.js
+++ b/lib/htmlelement.js
@@ -169,7 +169,7 @@ HTMLElement.prototype.removeChild = function (child) {
 }
 
 HTMLElement.prototype.getElementsByTagName = function (tagName) {
-  const lowerTagName = tagName.toLowerCase();
+  const lowerTagName = tagName.toLowerCase()
 
   if (this.isVoidEl || this.childNodes.length === 0) {
     return [];
@@ -177,11 +177,11 @@ HTMLElement.prototype.getElementsByTagName = function (tagName) {
 
   return this.childNodes.reduce(function (results, child) {
     if (lowerTagName === '*' || child.tagName === lowerTagName) {
-      return results.concat(child, child.getElementsByTagName(lowerTagName));
+      return results.concat(child, child.getElementsByTagName(lowerTagName))
     }
 
-    return results.concat(child.getElementsByTagName(lowerTagName));
-  }, []);
+    return results.concat(child.getElementsByTagName(lowerTagName))
+  }, [])
 }
 
 HTMLElement.prototype.getElementsByClassName = function (classNames) {

--- a/lib/utils/elementMatches.js
+++ b/lib/utils/elementMatches.js
@@ -1,0 +1,19 @@
+export function elementMatches(el, selector) {
+  if (el == null) {
+    return null
+  }
+
+  if (selector.tagName && el.tagName !== selector.tagName) {
+    return false
+  }
+
+  if (selector.id && el.id !== selector.id) {
+    return false
+  }
+
+  if (selector.classNames && !selector.classNames.every(cn => el.classList.contains(cn))) {
+    return false
+  }
+
+  return true
+}

--- a/lib/utils/parseSelector.js
+++ b/lib/utils/parseSelector.js
@@ -1,0 +1,31 @@
+const ws = /\s*([~+>])\s*/g
+const terms = /(^|[ >+])([^ >+]+)/ig
+
+const id = /#[^.>+ ]+/g
+const tagName = /^(?:[ >+])?([^#.>+ \[\]]+)/
+const classNames = /\.[^.>+ ]+/g
+
+const fst = a => a != null ? a[0] : null
+const snd = a => Array.isArray(a) && a.length > 1 ? a[1] : null
+const map = fn => as => Array.isArray(as) ? as.map(fn) : null
+
+const trimFirst = s => s.substr(1)
+const trimId = id => id != null ? trimFirst(id) : null
+const trimClassNames = map(trimFirst)
+
+export function parseSelector(selector) {
+  if (selector == null || selector.length === 0) {
+    return null
+  }
+
+  return selector
+    .replace(ws, '$1')
+    .match(terms)
+    .map((term, i) => ({
+      tagName: (snd(term.match(tagName)) || '').toLowerCase(),
+      id: trimId(fst(term.match(id))),
+      classNames: trimClassNames(term.match(classNames)),
+      relation: i > 0 ? term[0] : null
+    }))
+    .reverse()
+}

--- a/lib/utils/querySelector.js
+++ b/lib/utils/querySelector.js
@@ -1,0 +1,49 @@
+import { parseSelector } from './parseSelector'
+import { elementMatches } from './elementMatches'
+
+export function querySelector(query, root) {
+  const terms = parseSelector(query)
+
+  if (terms == null) {
+    return null
+  }
+
+  let init = root.getElementsByTagName(terms[0].tagName || '*')
+  let curr
+
+  for (let i = 0; i < init.length; i++) {
+    if (elementMatches(init[i], terms[0])) {
+      curr = init[i]
+      break
+    }
+  }
+
+  if (!curr) {
+    return null
+  }
+
+  for (let i = 1; i < terms.length; i++) {
+    switch (terms[i - 1].relation) {
+      case ' ':
+        // descendant, walk up the tree until a matching node is found
+        do {
+          curr = curr.parentNode
+        } while (curr != null && !elementMatches(curr, terms[i]))
+        break
+      case '>':
+        // immediate child
+        if (!elementMatches(curr.parentNode, terms[i])) {
+          return null
+        }
+        break
+      case '+':
+        // sibling selector
+        do {
+          curr = curr.nextSibling
+        } while (curr != null && !elementMatches(curr, terms[i]))
+        break
+    }
+  }
+
+  return curr
+}

--- a/test/querySelector.spec.js
+++ b/test/querySelector.spec.js
@@ -1,0 +1,82 @@
+const tape = require('tape');
+
+const { Document, HTMLElement } = require('../dist/nodom');
+
+tape('querySelector', t => {
+  const doc = new Document();
+
+  doc.documentElement.className = 'up-doc';
+
+  const section = doc.body.appendChild(new HTMLElement({ tagName: 'section' }));
+
+  const div1 = section.appendChild(new HTMLElement({ tagName: 'div', id: 'hello', className: 'beep' }));
+  const div2 = section.appendChild(new HTMLElement({ tagName: 'div', className: 'boop' }));
+
+  const p1 = div1.appendChild(new HTMLElement({ tagName: 'p', className: 'beep boop' }));
+  const p2 = div1.appendChild(new HTMLElement({ tagName: 'p', className: 'hello' }));
+  const p3 = div2.appendChild(new HTMLElement({ tagName: 'p', id: 'world', className: 'beep boop' }));
+  const p4 = div2.appendChild(new HTMLElement({ tagName: 'p', className: 'hello-world' }));
+
+  t.test('returns null with no results', t => {
+    t.plan(1);
+    const res = doc.querySelector('p.blooper');
+
+    t.equal(res, null);
+  });
+
+  t.test('select with tagName', t => {
+    t.plan(1);
+    const res = doc.querySelector('p');
+
+    t.equal(res, p1);
+  });
+
+  t.test('select with className', t => {
+    t.plan(1);
+    const res = doc.querySelector('.hello');
+
+    t.equal(res, p2);
+  });
+
+  t.test('select with id', t => {
+    t.plan(1);
+    const res = doc.querySelector('#world');
+
+    t.equal(res, p3);
+  });
+
+  t.test('select with tagName and className', t => {
+    t.plan(1);
+    const res = doc.querySelector('p.hello-world');
+
+    t.equal(res, p4);
+  });
+
+  t.test('descendant selector', t => {
+    t.plan(1);
+    const res = doc.querySelector('section p');
+
+    t.equal(res, section);
+  });
+
+  t.test('immediate child selector', t => {
+    t.plan(1);
+    const res = doc.querySelector('div > p');
+
+    t.equal(res, p1);
+  });
+
+  t.test('sibling selector', t => {
+    t.plan(1);
+    const res = doc.querySelector('p + p');
+
+    t.equal(res, p2);
+  });
+
+  t.test('subtree query', t => {
+    t.plan(1);
+    const res = section.querySelector('p');
+
+    t.equal(res, p1);
+  });
+});

--- a/test/utils/elementMatches.js
+++ b/test/utils/elementMatches.js
@@ -1,0 +1,55 @@
+const test = require('tape');
+const { HTMLElement } = require('../../dist/nodom');
+const { elementMatches } = require('../../lib/utils/elementMatches');
+
+const tags = [
+  new HTMLElement({ tagName: 'p' }),
+  new HTMLElement({ tagName: 'p', className: 'beep boop' }),
+  new HTMLElement({ tagName: 'p', className: 'boop beep', id: 'bzzt' })
+];
+
+test('utils/elementMatches', t => {
+  tags.forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: null,
+    id: null
+  }), true));
+
+  tags.slice(1).forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: ['beep'],
+    id: null
+  }), true));
+
+  tags.slice(1).forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: ['beep', 'boop'],
+    id: null
+  }), true));
+
+  tags.slice(2).forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: ['beep', 'boop'],
+    id: 'bzzt'
+  }), true));
+
+  tags.forEach(el => t.equal(elementMatches(el, {
+    tagName: 'div',
+    classNames: null,
+    id: null
+  }), false));
+
+  tags.forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: ['brrt'],
+    id: null
+  }), false));
+
+  tags.forEach(el => t.equal(elementMatches(el, {
+    tagName: 'p',
+    classNames: null,
+    id: 'gnngh'
+  }), false));
+
+  t.end();
+});

--- a/test/utils/parseSelector.js
+++ b/test/utils/parseSelector.js
@@ -1,0 +1,84 @@
+const test = require('tape');
+const { parseSelector } = require('../../lib/utils/parseSelector');
+
+test('utils/parseSelector', t => {
+  t.deepEqual(parseSelector('p'), [{
+    tagName: 'p',
+    id: null,
+    classNames: null,
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('p.hello'), [{
+    tagName: 'p',
+    id: null,
+    classNames: ['hello'],
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('p.hello.world'), [{
+    tagName: 'p',
+    id: null,
+    classNames: ['hello', 'world'],
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('p#beep'), [{
+    tagName: 'p',
+    id: 'beep',
+    classNames: null,
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('p#beep.boop'), [{
+    tagName: 'p',
+    id: 'beep',
+    classNames: ['boop'],
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('p#beep.boop.bzzt'), [{
+    tagName: 'p',
+    id: 'beep',
+    classNames: ['boop', 'bzzt'],
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('div p'), [{
+    tagName: 'p',
+    id: null,
+    classNames: null,
+    relation: ' '
+  }, {
+    tagName: 'div',
+    id: null,
+    classNames: null,
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('div > p'), [{
+    tagName: 'p',
+    id: null,
+    classNames: null,
+    relation: '>'
+  }, {
+    tagName: 'div',
+    id: null,
+    classNames: null,
+    relation: null
+  }]);
+
+  t.deepEqual(parseSelector('div + p'), [{
+    tagName: 'p',
+    id: null,
+    classNames: null,
+    relation: '+'
+  }, {
+    tagName: 'div',
+    id: null,
+    classNames: null,
+    relation: null
+  }]);
+
+  t.end();
+});


### PR DESCRIPTION
Initial implementation of querySelector.

Supports selectors composed of:

- tagName
- id
- classNames
- descendant
- child
- sibling

If there is demand for supporting more complex selectors, that wouldn't be very difficult to add later.

Should be `GO!`, as long as you're happy with it.