### PR TITLE
Fix/classlist classname sync

### DIFF
--- a/lib/classlist.js
+++ b/lib/classlist.js
@@ -1,23 +1,22 @@
 export function ClassList (el) {
-  const classNames = (el.className && el.className.split(' ')) || []
+  this.reset(el.className)
+}
+
+ClassList.prototype = []
+
+ClassList.prototype.reset = function (className) {
+  const classNames = (className || '').split(' ')
 
   this.length = classNames.length
 
   for (let i = 0; i < classNames.length; i++) {
     this[i] = classNames[i]
   }
-
-  this._updateClassName = function () {
-    el.className = this.join(' ')
-  }
 }
-
-ClassList.prototype = []
 
 ClassList.prototype.add = function (className) {
   if (!this.contains(className)) {
     this.push(className)
-    this._updateClassName()
   }
 }
 
@@ -36,7 +35,10 @@ ClassList.prototype.remove = function (className) {
   for (let i = 0; i < this.length; i++) {
     if (classNames[i] === className) {
       this.splice(i, 1)
-      this._updateClassName()
     }
   }
+}
+
+ClassList.prototype.toString = function () {
+  return this.join(' ').trim()
 }

--- a/lib/htmlelement.js
+++ b/lib/htmlelement.js
@@ -228,6 +228,14 @@ Object.defineProperties(HTMLElement.prototype, {
       return this._classList
     }
   },
+  className: {
+    set: function (v) {
+      this.classList.reset(v)
+    },
+    get: function () {
+      return this._classList == null ? '' : this._classList.toString()
+    }
+  },
   innerHTML: {
     get: function () {
       return this._innerHTML || this.render(true)

--- a/test/classlist.spec.js
+++ b/test/classlist.spec.js
@@ -1,0 +1,24 @@
+import test from 'tape'
+import { ClassList } from '../lib/classlist'
+
+test('ClassList', t => {
+  t.test('returns a className represenation in toString', t => {
+    t.plan(1)
+
+    const c = new ClassList({ className: 'beep boop' })
+
+    t.equal(c.toString(), 'beep boop')
+  })
+
+  t.test('replaces it\'s contents on reset', t => {
+    t.plan(2)
+
+    const c = new ClassList({ className: 'beep boop bzzt' })
+
+    t.equal(c.toString(), 'beep boop bzzt')
+
+    c.reset('hello world')
+
+    t.equal(c.toString(), 'hello world')
+  })
+})

--- a/test/htmlelement.spec.js
+++ b/test/htmlelement.spec.js
@@ -1,0 +1,50 @@
+import test from 'tape'
+import { HTMLElement } from '../lib/htmlelement'
+
+test('HTMLElement', t => {
+  t.test('initially has an ampty className', t => {
+    t.plan(1)
+
+    const el = new HTMLElement()
+
+    t.equal(el.className, '')
+  })
+
+  t.test('className can be assigned to', t => {
+    t.plan(1)
+
+    const el = new HTMLElement()
+    el.className = 'beep boop'
+    t.equal(el.className, 'beep boop')
+  })
+
+  t.test('assigning to className updates classList', t => {
+    t.plan(2)
+
+    const el = new HTMLElement()
+    el.className = 'beep boop'
+
+    t.equal(el.classList.contains('beep'), true)
+    t.equal(el.classList.contains('boop'), true)
+  })
+
+  t.test('updating classList updates className', t => {
+    t.plan(1)
+
+    const el = new HTMLElement()
+    el.classList.add('beep')
+    el.classList.add('boop')
+
+    t.equal(el.className, 'beep boop')
+  })
+
+  t.test('className and classList are up to date from initial props', t => {
+    t.plan(3)
+
+    const el = new HTMLElement({ className: 'beep boop' })
+
+    t.equal(el.className, 'beep boop')
+    t.equal(el.classList.contains('beep'), true)
+    t.equal(el.classList.contains('boop'), true)
+  })
+})


### PR DESCRIPTION
Adds non-standard methods `.reset` and `.toString` to `ClassList`, setter and getter for `HTMLElement.className`, and uses those to keep `HTMLElement.className` and `HTMLElement.classList` in sync.

Tests included.

Closes https://github.com/pakastin/nodom/issues/11